### PR TITLE
Release 2.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.63)
-AC_INIT([ibus-cangjie], [2.0], [https://github.com/Cangjians/ibus-cangjie/issues], [ibus-cangjie], [https://github.com/Cangjians/ibus-cangjie])
+AC_INIT([ibus-cangjie], [2.1], [https://github.com/Cangjians/ibus-cangjie/issues], [ibus-cangjie], [https://github.com/Cangjians/ibus-cangjie])
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
And here's the latest ibus-cangjie release.

The changes in this version are:
- Add a link to the release tarballs in the README (Mathieu)
- Actually run the unit tests on « make check » (Anthony)
- Improve « make clean » (Anthony)
- Add install instructions for a few distributions (Mathieu)
- Improve the optionality of pycanberra (Mathieu)
- Fix the pt_BR translation (Mathieu)
- Reset sys.path to limit side effects on the unit tests (Mathieu)
- Ensure validity of the preferences UI file (Mathieu)
- Fix the UI file (Mathieu)

Users are **highly** encouraged to upgrade.

Happy Chinese New Year!
