### PR TITLE
Release 2.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.63)
-AC_INIT([ibus-cangjie], [2.1], [https://github.com/Cangjians/ibus-cangjie/issues], [ibus-cangjie], [https://github.com/Cangjians/ibus-cangjie])
+AC_INIT([ibus-cangjie], [2.2], [https://github.com/Cangjians/ibus-cangjie/issues], [ibus-cangjie], [https://github.com/Cangjians/ibus-cangjie])
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
Here's a minor release.

---
### Bug Fixes
- Fixed using the numpad to commit candidates. (Mathieu)
### Docs Improvements
- Added installation instructions for Arch Linux. (Antony)
- Removed an obsolete (and confusing) notice about release tarballs. (Mathieu)
### Testing improvements
- Get Travis CI to build against the 1.x branch of libcangjie and pycangjie, as
  their master branch has now broken the API in a way that ibus-cangjie 1.x
  doesn't build against it any more. (Mathieu)
- Use the in-memory GSettings backend for the tests, so avoid any undesired
  side-effects from the running environment. (Mathieu)
