### PR TITLE
Correct translation string

### DIFF
--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -98,7 +98,7 @@ msgstr "輸入法版本"
 msgid ""
 "Only characters common in Hong Kong can be inputted by default.\n"
 "The following additional characters can be enabled:"
-msgstr "預設情況下只能輸入香港常用字。\n可以額外啟用下列額字元："
+msgstr "預設情況下只能輸入香港常用字。\n可以額外啟用下列字元："
 
 #. The Taiwanese Zhuyin alphabet is known under two names in English.
 #. Obviously, if it only has one name in your language, don't try to keep two


### PR DESCRIPTION
There is an extra "額" in "可以額外啟用下列額字元" in the configuration
page, the second "額" should be eliminated. It is now.

This commit fixes issue #62.
