### PR TITLE
engine: Deduplicate characters

### DIFF
--- a/src/engine.py
+++ b/src/engine.py
@@ -394,9 +394,16 @@ class Engine(IBus.Engine):
         else:
             chars = self.cangjie.get_characters_by_shortcode(code)
 
+        # Finding an element in a dict is **much** faster than in a list
+        seen = {}
+
         for c in sorted(chars, key=attrgetter("frequency"), reverse=True):
+            if c.chchar in seen:
+                continue
+
             self.lookuptable.append_candidate(IBus.Text.new_from_string(c.chchar))
             num_candidates += 1
+            seen[c.chchar] = True
 
         if num_candidates == 1:
             self.do_select_candidate(1)


### PR DESCRIPTION
This avoids having twice the same candidate in the list presented to the
user.

Fixes #63
