### PR TITLE
setup: Don't traceback when the halfwidth-chars property changes

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -99,6 +99,9 @@ class Setup(object):
         We need to react, in case the value was changed from somewhere else,
         for example from another setup UI.
         """
+        if key == "halfwidth-chars":
+            return
+
         if key == "version":
             new_value = self.settings.get_int(key)
 


### PR DESCRIPTION
The issue would only happen if a user changed the property while the setup dialog was opened.

It doesn't crash the dialog, it just sends a traceback, but it is still pretty ugly as it can get caught by crash-reporting systems like ABRT or Apport.