### PR TITLE
Hide the setup menu entries

### DIFF
--- a/data/ibus-setup-cangjie.desktop.in.in
+++ b/data/ibus-setup-cangjie.desktop.in.in
@@ -10,4 +10,4 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Categories=Settings;
-NotShowIn=GNOME;
+NoDisplay=true

--- a/data/ibus-setup-quick.desktop.in.in
+++ b/data/ibus-setup-quick.desktop.in.in
@@ -10,4 +10,4 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Categories=Settings;
-NotShowIn=GNOME;
+NoDisplay=true


### PR DESCRIPTION
We were hiding them on GNOME, because the normal interaction is for
users to get to those through the GNOME Settings.

However, other desktops can have similar behaviours, and when they don't
the normal experience is to get to them through the global IBus setup
tool.

As a result, let's always hide those menu entries.

This prevents an issue where they appear in the menus of some desktops,
without an icon:

    https://bugzilla.redhat.com/show_bug.cgi?id=1626809