### PR TITLE
Properly import gi modules to avoid PyGIWarning

### DIFF
--- a/scripts/ibus-engine-cangjie.in
+++ b/scripts/ibus-engine-cangjie.in
@@ -20,6 +20,9 @@
 import argparse
 import locale
 
+import gi
+gi.require_version('IBus','1.0')
+
 from gi.repository import IBus
 
 from ibus_cangjie import IMApp

--- a/scripts/ibus-setup-cangjie.in
+++ b/scripts/ibus-setup-cangjie.in
@@ -32,6 +32,10 @@ GLib.set_prgname('ibus-setup-%s' % args.engine)
 
 import locale
 
+import gi
+gi.require_version('Gtk','3.0')
+gi.require_version('IBus','1.0')
+
 from gi.repository import Gtk
 from gi.repository import IBus
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -16,6 +16,9 @@
 # along with ibus-cangjie.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import gi
+gi.require_version('IBus','1.0')
+
 from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import IBus

--- a/src/engine.py
+++ b/src/engine.py
@@ -22,6 +22,9 @@ __all__ = ["EngineCangjie", "EngineQuick"]
 import gettext
 from operator import attrgetter
 
+import gi
+gi.require_version('IBus','1.0')
+
 from gi.repository import Gio
 from gi.repository import IBus
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -18,6 +18,12 @@
 
 from gettext import dgettext
 
+import gi
+gi.require_version('Gdk','3.0')
+gi.require_version('Gio','3.0')
+gi.require_version('GLib','3.0')
+gi.require_version('Gtk','3.0')
+
 from gi.repository import Gdk
 from gi.repository import Gio
 from gi.repository import GLib

--- a/tests/test_cangjie.py
+++ b/tests/test_cangjie.py
@@ -19,6 +19,9 @@
 import os
 import unittest
 
+import gi
+gi.require_version('IBus','1.0')
+
 from gi.repository import IBus
 
 from ibus_cangjie.engine import *

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -33,6 +33,8 @@ def has_graphical():
     automatically skip the tests which can't run without.
     """
     try:
+        import gi
+        gi.require_version('Gtk', '3.0')
         from gi.repository import Gtk
 
     except RuntimeError as e:
@@ -43,6 +45,7 @@ def has_graphical():
     # But other platforms (e.g Fedora 21) can import Gtk just fine even
     # without a display...
 
+    gi.require_version('Gdk', '3.0')
     from gi.repository import Gdk
 
     if Gdk.Display.get_default() is None:


### PR DESCRIPTION
Fix #86 

Verification build could be found at https://build.opensuse.org/package/show/M17N/ibus-cangjie